### PR TITLE
Implement recursive scanning and analysis enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+codecompass_report.json
+codecompass_report.md
+codecompass_report.html

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # CodeCompass
 Não se perca no legado — deixe o CodeCompass guiar.
+
+## Uso
+
+Execute `python codecompass.py [diretório-ou-arquivo]` para gerar relatórios JSON, Markdown e HTML.
+Se nenhum argumento for informado, o diretório atual é varrido recursivamente.


### PR DESCRIPTION
## Summary
- add recursive file scanning
- add simple heuristics for generating example suggestions
- produce HTML reports alongside JSON and Markdown
- update command line handling
- document usage instructions
- ignore generated reports in git

## Testing
- `python -m py_compile codecompass.py`
- `python codecompass.py`

------
https://chatgpt.com/codex/tasks/task_e_687047310054832c81b3c5f6e211cf62